### PR TITLE
add css to prettify links

### DIFF
--- a/inst/htmlwidgets/lib/vega-embed/vega-embed.css
+++ b/inst/htmlwidgets/lib/vega-embed/vega-embed.css
@@ -1,0 +1,16 @@
+/* Adapted from css used by  Altair documentation website
+https://raw.githubusercontent.com/altair-viz/altair/169c498537571b16f7852d31564b5372274f3cca/doc/_static/altair-plot.css
+*/
+
+.vega-embed .vega-actions > a {
+  color: #757575;
+  font-weight: normal;
+  font-size: 13px;
+  margin-right: 1em;
+  text-decoration: none;
+}
+
+.vega-embed .vega-actions > a:hover {
+  cursor: pointer;
+}
+

--- a/inst/htmlwidgets/vegalite.yaml
+++ b/inst/htmlwidgets/vegalite.yaml
@@ -16,6 +16,8 @@ dependencies:
     src: htmlwidgets/lib/vega-embed
     script:
       - vega-embed-modified.js
+    style:
+      - vega-embed.css
   - name: vega-tooltip
     version: 0.7.0
     src: htmlwidgets/lib/vega-tooltip


### PR DESCRIPTION
Adds css similar to what is used in the Altair documentation website for #20 .  There is a link in the css added to the package to the css that was adapted (since this wasn't a direct pull without changes, not sure of best way to document).  I named the css vega-embed.css but that might not be an appropriate name as it differs from the [vega-embed.css](https://github.com/vega/vega-embed/blob/master/vega-embed.css) that recently was added to vega-embed repository (I thought the Altair documentation website plots/links looked nicer). 

Figures now look like:
![altair_r_links_new](https://user-images.githubusercontent.com/6809790/38909530-cd55e16e-4279-11e8-9d2f-de31853df2ed.png)

Note: I tried to update the pkgdown site but I got a pandoc error, so I have not updated the website with this change.  
